### PR TITLE
feat(create-secret): add two expiration options

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -166,7 +166,7 @@ const keyParameter = "{key:(?:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})}"
 // validExpiration validates that expiration is either
 // 3600(1hour), 86400(1day) or 604800(1week)
 func validExpiration(expiration int32) bool {
-	for _, ttl := range []int32{3600, 86400, 604800} {
+	for _, ttl := range []int32{3600, 86400, 604800, 1209600, 2592000} {
 		if ttl == expiration {
 			return true
 		}

--- a/website/public/locales/en.json
+++ b/website/public/locales/en.json
@@ -68,7 +68,9 @@
     "legend": "The encrypted message will be deleted automatically after",
     "optionOneHourLabel": "One Hour",
     "optionOneDayLabel": "One Day",
-    "optionOneWeekLabel": "One Week"
+    "optionOneWeekLabel": "One Week",
+    "optionTwoWeeksLabel": "Two Weeks",
+    "optionOneMonthLabel": "One Month"
   },
   "features": {
     "title": "Share Secrets Securely With Ease",

--- a/website/src/shared/Expiration.tsx
+++ b/website/src/shared/Expiration.tsx
@@ -48,6 +48,18 @@ export const Expiration = (props: { control: Control<any> }) => {
               control={<Radio color="primary" />}
               label={t('expiration.optionOneWeekLabel') as string}
             />
+            <FormControlLabel
+              labelPlacement="end"
+              value="1209600"
+              control={<Radio color="primary" />}
+              label={t('expiration.optionTwoWeeksLabel') as string}
+            />
+            <FormControlLabel
+              labelPlacement="end"
+              value="2592000"
+              control={<Radio color="primary" />}
+              label={t('expiration.optionOneMonthLabel') as string}
+            />
           </RadioGroup>
         )}
       />


### PR DESCRIPTION
Add 2 expiration options when creating a secret:
- 2 weeks (14 days, 1209600 seconds)
- 1 month (30 days, 2592000 seconds)